### PR TITLE
fix for the all command

### DIFF
--- a/console.py
+++ b/console.py
@@ -116,20 +116,20 @@ class HBNBCommand(cmd.Cmd):
         """Handler for all command"""
         pattern = r"^(?P<class>\w+)?\ ?" + r"(?P<extra>.*)$"
         tokens = re.search(pattern, args).groupdict()  # type: ignore
-        if not tokens["class"]:
-            obj_list = [str(obj) for obj in storage.all().values()]
-            print(obj_list)
-            return
-        if tokens["class"] not in self.__valid_classes:
+
+        if tokens["class"] and tokens["class"] not in self.__valid_classes:
             print("** class doesn't exist **")
             return
 
-        obj_list = [
+        # build the list containig the string representation of the objects
+        obj_str_list = [
             str(obj)
             for obj in storage.all().values()
-            if type(obj).__name__ == tokens["class"]
+            if not tokens["class"] or type(obj).__name__ == tokens["class"]
         ]
-        print(obj_list)
+
+        if obj_str_list != []:
+            print(obj_str_list)
 
     def do_update(self, args):
         """Handler for the update command"""

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -198,7 +198,7 @@ class HBNBCommandAll(TestCase):
     def test_all_without_class_name(self):
         """all - no class name"""
         obj_list = [str(obj) for obj in storage.all().values()]
-        output_exp = str(obj_list) + "\n"
+        output_exp = "" if obj_list == [] else str(obj_list) + "\n"
         output_got = get_cmd_output("all")
         self.assertEqual(output_got, output_exp)
 
@@ -210,7 +210,7 @@ class HBNBCommandAll(TestCase):
                 for obj in storage.all().values()
                 if type(obj).__name__ == cls
             ]
-            output_exp = str(obj_list) + "\n"
+            output_exp = "" if obj_list == [] else str(obj_list) + "\n"
             output_got = get_cmd_output(f"all {cls}")
             self.assertEqual(output_got, output_exp)
 
@@ -426,7 +426,7 @@ class HBNBCommandAllAdvanced(TestCase):
                 for obj in storage.all().values()
                 if type(obj).__name__ == cls
             ]
-            output_exp = str(obj_list) + "\n"
+            output_exp = "" if obj_list == [] else str(obj_list) + "\n"
             output_got = get_cmd_output(f"{cls}.all()")
             self.assertEqual(output_got, output_exp)
 


### PR DESCRIPTION
It mustn't print anything if the list containing the string representation of objects is empty